### PR TITLE
Relax DataStructures compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,5 +7,5 @@ version = "0.2.0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
 [compat]
-DataStructures = "0.18.6"
+DataStructures = "^0.17"
 julia = "^1.2"


### PR DESCRIPTION
This reduce conflicts with other packages as DataStructures = "0.18.6" was likely overly specific